### PR TITLE
サインインの度に認可フローを通す

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -5,7 +5,16 @@ import Google from "next-auth/providers/google";
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
     /* override */
-    Google({ authorization: { params: { scope: "openid email profile https://www.googleapis.com/auth/calendar"}}})
+    Google({
+      authorization: {
+        params: {
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code",
+          scope: "openid email profile https://www.googleapis.com/auth/calendar"
+        }
+      }
+    })
   ],
   callbacks: {
    async jwt({ token, account }) {


### PR DESCRIPTION
## 概要
リフレッシュトークンによる永続化はいらないと判断

## 関連タスク
Close #3  (required)

## やったこと


## やらないこと
- セッション管理。アクセストークンの有効期限が切れたときの処理は実装していない

## レビュー事項
-

## 補足 参考情報


